### PR TITLE
Minor fixes

### DIFF
--- a/core/contracts/MaxBiddingMintStrategy.sol
+++ b/core/contracts/MaxBiddingMintStrategy.sol
@@ -40,8 +40,11 @@ contract MaxBiddingMintStrategy is IMintStrategy {
         override
         returns (uint256[] memory)
     {
-        for (uint256 i = 0; i < gobblerIds.length; i++) {
+        for (uint256 i = 0; i < gobblerIds.length; ) {
             if (artGobbler.getGobblerEmissionMultiple(gobblerIds[i]) == 0) revert UnrevealedGobbler();
+            unchecked {
+                ++i;
+            }
         }
         return gobblerIds;
     }

--- a/core/contracts/MultiplyGobblerVault.sol
+++ b/core/contracts/MultiplyGobblerVault.sol
@@ -12,7 +12,7 @@ import { toDaysWadUnsafe } from "solmate/src/utils/SignedWadMath.sol";
 
 /// @title Vault to multiply your Gobblers
 /// @author Ankit Chiplunkar
-/// @notice Use this contract to stake Gobblers and mint based on stratergies
+/// @notice Use this contract to stake Gobblers and mint based on strategies
 /// @dev Contract accepts Gobblers and uses the generated Goo to buy more Gobblers
 contract MultiplyGobblerVault is ERC20, Owned, ReentrancyGuard {
     /*//////////////////////////////////////////////////////////////
@@ -28,7 +28,7 @@ contract MultiplyGobblerVault is ERC20, Owned, ReentrancyGuard {
     address public taxAddress;
 
     /*//////////////////////////////////////////////////////////////
-                Variables updated each mint    
+                Variables updated each mint
     //////////////////////////////////////////////////////////////*/
     /// @notice The emission multiple after the last mint
     uint256 public lastMintEmissionMultiple;
@@ -139,9 +139,9 @@ contract MultiplyGobblerVault is ERC20, Owned, ReentrancyGuard {
                 INTERNAL FUNCTIONS
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Mints mgob tokens to the receiver
+    /// @notice Mints mGOB tokens to the receiver
     /// @dev If deposit tax is active (0.5% tokens) sends the deposit tax to the owner
-    /// @param multplierToMint the multiplier of the Gobbler deposited
+    /// @param multiplierToMint the multiplier of the Gobbler deposited
     /// @param conversionRate the conversion rate at the time of the erc20 token mint
     /// @param receiver the receiver of the erc20 tokens
     function _mgobMint(
@@ -165,7 +165,7 @@ contract MultiplyGobblerVault is ERC20, Owned, ReentrancyGuard {
 
     /// @notice Deposit Gobbler into the vault and get mGOB tokens proportional to multiplier of the Gobbler
     /// @dev This requires an approve before the deposit
-    /// @dev If GooDeposit is non-zero than take goo with Gobbler and also add it into Vault's virtual balance
+    /// @dev If GooDeposit is non-zero then take goo with Gobbler and also add it into Vault's virtual balance
     /// @param id id of the gobbler to mint
     function deposit(uint256 id) public {
         // multiplier of to be deposited gobbler
@@ -183,7 +183,7 @@ contract MultiplyGobblerVault is ERC20, Owned, ReentrancyGuard {
         _mgobMint(multiplier, getConversionRate(), msg.sender);
     }
 
-    /// @notice Withdraw Gobbler from the vault and deposit mGOB tokens proportional to multiplier of the Gobbler
+    /// @notice Withdraw Gobbler from the vault and burn mGOB tokens proportional to multiplier of the Gobbler
     /// @dev Cannot withdraw an unrevealed Gobbler i.e. multiplier = 0
     /// @param id id of the gobbler to withdraw
     function withdraw(uint256 id) public {
@@ -196,7 +196,7 @@ contract MultiplyGobblerVault is ERC20, Owned, ReentrancyGuard {
         artGobbler.safeTransferFrom(address(this), msg.sender, id);
     }
 
-    /// @notice Deposit Gobbler inbetween mints without depositing any Goo,
+    /// @notice Deposit Gobbler in between mints without depositing any Goo,
     /// @dev Updates the mapping laggingDeposit for the user to be able to claim tokens equal to deposited multiplier
     /// @dev Updates the variable totalLaggedMultiple so that the conversionRate does not change due to a lagged deposit
     /// @dev mGOB tokens can only be claimed after a new Gobbler is minted
@@ -234,7 +234,7 @@ contract MultiplyGobblerVault is ERC20, Owned, ReentrancyGuard {
         }
     }
 
-    /// @notice Mint a gobbler form generated Goo
+    /// @notice Mint a gobbler from generated Goo
     /// @dev Any address can call this function and mint a Gobbler
     /// @dev Strategy should return Goo > GobblerPrice() for the transaction to succeed
     /// @dev Also stores emissionMultiple, GooBalance and Timestamp at time of mint
@@ -250,7 +250,7 @@ contract MultiplyGobblerVault is ERC20, Owned, ReentrancyGuard {
         emit GobblerMinted(mintedGobbledId[totalMinted]);
     }
 
-    /// @notice Mint a legendary Gobbler form Gobblers in the vault
+    /// @notice Mint a legendary Gobbler from Gobblers in the vault
     /// @dev Any address can call this function and mint a Legendary Gobbler
     /// @dev Adding reentrancy guard since folks can deposit mint and then withdraw instantly after
     function mintLegendaryGobbler(uint256[] calldata gobblerIds) public nonReentrant {

--- a/core/contracts/MultiplyGobblerVault.sol
+++ b/core/contracts/MultiplyGobblerVault.sol
@@ -64,7 +64,6 @@ contract MultiplyGobblerVault is ERC20, Owned, ReentrancyGuard {
     /*//////////////////////////////////////////////////////////////
                 ERRORS
     //////////////////////////////////////////////////////////////*/
-    error GooDepositFailed();
     error TotalMintedIsZero();
     error ClaimingInLowerMintWindow();
     error UnrevealedGobbler();
@@ -109,7 +108,7 @@ contract MultiplyGobblerVault is ERC20, Owned, ReentrancyGuard {
             uint256 vaultMultiple = artGobbler.getUserEmissionMultiple(address(this));
             return totalSupply / (vaultMultiple - totalLaggedMultiple);
         }
-        return 10**18;
+        return 1e18;
     }
 
     /// @notice Returns the Goo to be deposited with a Gobbler

--- a/core/contracts/MultiplyGobblerVault.sol
+++ b/core/contracts/MultiplyGobblerVault.sol
@@ -5,7 +5,6 @@ import { IArtGobbler } from "./IArtGobbler.sol";
 import { IMintStrategy } from "./IMintStrategy.sol";
 import { ERC20 } from "solmate/src/tokens/ERC20.sol";
 import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
-import { ERC721TokenReceiver } from "solmate/src/tokens/ERC721.sol";
 import { ReentrancyGuard } from "solmate/src/utils/ReentrancyGuard.sol";
 import { Owned } from "solmate/src/auth/Owned.sol";
 import { LibGOO } from "./LibGOO.sol";
@@ -15,7 +14,7 @@ import { toDaysWadUnsafe } from "solmate/src/utils/SignedWadMath.sol";
 /// @author Ankit Chiplunkar
 /// @notice Use this contract to stake Gobblers and mint based on stratergies
 /// @dev Contract accepts Gobblers and uses the generated Goo to buy more Gobblers
-contract MultiplyGobblerVault is ERC20, ERC721TokenReceiver, Owned, ReentrancyGuard {
+contract MultiplyGobblerVault is ERC20, Owned, ReentrancyGuard {
     /*//////////////////////////////////////////////////////////////
                 ADDRESS VARIABLES
     //////////////////////////////////////////////////////////////*/

--- a/core/contracts/MultiplyGobblerVault.sol
+++ b/core/contracts/MultiplyGobblerVault.sol
@@ -205,11 +205,12 @@ contract MultiplyGobblerVault is ERC20, Owned, ReentrancyGuard {
     function depositWithLag(uint256 id) public {
         // multiplier of to be deposited gobbler
         uint256 multiplier = artGobbler.getGobblerEmissionMultiple(id);
-        // transfer art gobbler into the vault
-        artGobbler.safeTransferFrom(msg.sender, address(this), id);
         // update users laggingDeposit amounts
         laggingDeposit[msg.sender][totalMinted] += multiplier;
         totalLaggedMultiple += multiplier;
+
+        // transfer art gobbler into the vault
+        artGobbler.transferFrom(msg.sender, address(this), id);
     }
 
     /// @notice Claim the tokens from a lagged deposit

--- a/core/contracts/MultiplyGobblerVault.sol
+++ b/core/contracts/MultiplyGobblerVault.sol
@@ -59,7 +59,7 @@ contract MultiplyGobblerVault is ERC20, Owned, ReentrancyGuard {
     /// @notice Mapping to keep track of which addresses have deposited how many multipliers in which totalMint
     mapping(address => mapping(uint256 => uint256)) public laggingDeposit;
     /// @notice Mapping to keep track of which mintNumber mints which gobblerId
-    mapping(uint256 => uint256) public mintedGobbledId;
+    mapping(uint256 => uint256) public mintedGobblerId;
 
     /*//////////////////////////////////////////////////////////////
                 ERRORS
@@ -223,7 +223,7 @@ contract MultiplyGobblerVault is ERC20, Owned, ReentrancyGuard {
             // cannot claim deposit if the next gobbler has not been minted
             if (totalMinted <= mintNumber) revert ClaimingInLowerMintWindow();
             // cannot claim deposit if the minted gobbler has not been revealed
-            uint256 mintedGobblerMultiplier = artGobbler.getGobblerEmissionMultiple(mintedGobbledId[mintNumber]);
+            uint256 mintedGobblerMultiplier = artGobbler.getGobblerEmissionMultiple(mintedGobblerId[mintNumber]);
             if (mintedGobblerMultiplier == 0) revert MintedGobblerUnrevealed();
             uint256 sendersLaggedMultiple = laggingDeposit[msg.sender][mintNumber];
             _mgobMint(sendersLaggedMultiple, getConversionRate(), msg.sender);
@@ -243,12 +243,12 @@ contract MultiplyGobblerVault is ERC20, Owned, ReentrancyGuard {
     /// @dev In expectation of paying less Goo balance on Deposit
     /// @dev They will lose out on minted multiplier rewards by the time they deposit
     function mintGobbler() public {
-        mintedGobbledId[totalMinted] = artGobbler.mintFromGoo(mintStrategy.gobblerMintStrategy(), true);
+        mintedGobblerId[totalMinted] = artGobbler.mintFromGoo(mintStrategy.gobblerMintStrategy(), true);
         lastMintEmissionMultiple = artGobbler.getUserEmissionMultiple(address(this));
         lastMintGooBalance = artGobbler.gooBalance(address(this));
         lastMintTimestamp = block.timestamp;
-        totalMinted += 1;
-        emit GobblerMinted(mintedGobbledId[totalMinted]);
+        ++totalMinted;
+        emit GobblerMinted(mintedGobblerId[totalMinted]);
     }
 
     /// @notice Mint a legendary Gobbler from Gobblers in the vault

--- a/core/contracts/MultiplyGobblerVault.sol
+++ b/core/contracts/MultiplyGobblerVault.sol
@@ -144,17 +144,18 @@ contract MultiplyGobblerVault is ERC20, Owned, ReentrancyGuard {
     /// @param conversionRate the conversion rate at the time of the erc20 token mint
     /// @param receiver the receiver of the erc20 tokens
     function _mgobMint(
-        uint256 multplierToMint,
+        uint256 multiplierToMint,
         uint256 conversionRate,
         address receiver
     ) internal {
+        uint256 mintAmount = multiplierToMint * conversionRate;
         // mint the mGOB tokens to receiver
         if (totalMinted > DEPOSIT_TAX_START_AFTER) {
-            uint256 depositTax = (multplierToMint * conversionRate * TAX_RATE) / PRECISION;
+            uint256 depositTax = (mintAmount * TAX_RATE) / PRECISION;
             _mint(taxAddress, depositTax);
-            _mint(receiver, multplierToMint * conversionRate - depositTax);
+            _mint(receiver, mintAmount - depositTax);
         } else {
-            _mint(receiver, multplierToMint * conversionRate);
+            _mint(receiver, mintAmount);
         }
     }
 

--- a/core/contracts/MultiplyGobblerVault.sol
+++ b/core/contracts/MultiplyGobblerVault.sol
@@ -218,7 +218,7 @@ contract MultiplyGobblerVault is ERC20, ERC721TokenReceiver, Owned, ReentrancyGu
     /// @dev Updates the variable totalLaggedMultiple so that the conversionRate does not change due to a lagged deposit
     /// @param whenMinted which multipliers to claim
     function claimLagged(uint256[] calldata whenMinted) public {
-        for (uint256 i = 0; i < whenMinted.length; i++) {
+        for (uint256 i = 0; i < whenMinted.length; ) {
             uint256 mintNumber = whenMinted[i];
             // cannot claim deposit if the next gobbler has not been minted
             if (totalMinted <= mintNumber) revert ClaimingInLowerMintWindow();
@@ -229,6 +229,9 @@ contract MultiplyGobblerVault is ERC20, ERC721TokenReceiver, Owned, ReentrancyGu
             _mgobMint(sendersLaggedMultiple, getConversionRate(), msg.sender);
             laggingDeposit[msg.sender][mintNumber] = 0;
             totalLaggedMultiple -= sendersLaggedMultiple;
+            unchecked {
+                ++i;
+            }
         }
     }
 

--- a/core/test/gobblerMultiplier.test.ts
+++ b/core/test/gobblerMultiplier.test.ts
@@ -168,7 +168,7 @@ describe("Multiply Gobbler tests", () => {
     await mockArtGobbler.setUserEmissionMultiple(multiplyGobbler.address, 5);
     const totalMinted = await multiplyGobbler.totalMinted();
     await multiplyGobbler.connect(deployer).mintGobbler();
-    const mintedGobblerId = await multiplyGobbler.mintedGobbledId(totalMinted);
+    const mintedGobblerId = await multiplyGobbler.mintedGobblerId(totalMinted);
     await mockArtGobbler.unrevealGobbler(mintedGobblerId);
     await expect(multiplyGobbler.connect(deployer).withdraw(mintedGobblerId)).to.be.revertedWithCustomError(
       multiplyGobbler,


### PR DESCRIPTION
Here are a few small fixes from reading over the contracts—mostly small gas optimizations and comment fixes. A few bigger changes:

- Since this contract is not actually meant to receive ERC721 transfers via `safeTransferFrom`, it doesn't need `ERC721Receiver`. In fact, it's good not to include it, since there's no mechanism to withdraw a token transferred this way. (`safeTransferFrom` has gotta be the most confusing, counterintuitive part of the ERC721 spec).
- Updated the order of operations in a couple places to follow checks-effects-interactions. There are no reentrant callbacks, but it's a good pattern anyways.

A few further questions:
- I don't understand the reentrancy protection on `mintLegendaryGobbler`. What is the sequence of operations that might be reentrant?
- I anticipate some users might be surprised by the fact that the Gobbler they deposit is not necessarily the Gobbler they withdraw. They'll get back a Gobbler with the same or greater multiplier, but there's no guarantee it will be the one they deposited. In that sense, this is more like an NFTX pool or similar than a vault. Seems important to make this really clear for end users.
- Along similar lines, I can imagine a griefing scenario where it might be possible to lock low-multiplier users in the vault by depositing high-multiplier gobblers and withdrawing low-multiplier gobblers, leaving the low-multiplier depositors unable to withdraw until their shares appreciate. This is probably not in the griefer's self interest, but I think it's worth considering.
- Finally, is it possible for extra goo to end up stuck and unclaimed in the contract?